### PR TITLE
Add a workflow to automatically create/update major tags/releases

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ steps.highest.outputs.tag }}
       - name: Update major version tags
         if: steps.highest.outputs.is_highest == 'true'
-      - uses: haya14busa/action-update-semver@v1
+        uses: haya14busa/action-update-semver@v1
         with:
           tag: ${{ steps.highest.outputs.tag }}
           major_version_tag_only: true

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -12,19 +12,72 @@ jobs:
     if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.release.tag_name }}
-      - uses: haya14busa/action-update-semver@v1
-        with:
-          tag: ${{ github.event.release.tag_name }}
-          major_version_tag_only: true
-      - name: Update major release description
+      - name: Resolve highest version for major
+        id: highest
         uses: actions/github-script@v7
         with:
           script: |
             const tag = context.payload.release.tag_name;
             const majorTag = tag.split('.')[0];
+            const majorNum = parseInt(majorTag.replace(/^v/, ''), 10);
+
+            const { data: releases } = await octokit.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+
+            const inMajor = releases
+              .filter(r => !r.draft && !r.prerelease)
+              .map(r => r.tag_name)
+              .filter(t => {
+                const match = t.match(/^v?(\d+)\.(\d+)\.(\d+)(?:-|$)/);
+                return match && parseInt(match[1], 10) === majorNum;
+              });
+
+            if (inMajor.length === 0) {
+              core.setOutput('tag', tag);
+              core.setOutput('major_tag', majorTag);
+              core.setOutput('is_highest', 'true');
+              return;
+            }
+
+            const parsed = inMajor.map(t => {
+              const m = t.match(/^v?(\d+)\.(\d+)\.(\d+)/);
+              return { tag: t, parts: [parseInt(m[1],10), parseInt(m[2],10), parseInt(m[3],10)] };
+            });
+            parsed.sort((a, b) => {
+              if (a.parts[0] !== b.parts[0]) return b.parts[0] - a.parts[0];
+              if (a.parts[1] !== b.parts[1]) return b.parts[1] - a.parts[1];
+              return b.parts[2] - a.parts[2];
+            });
+
+            const highestTag = parsed[0].tag;
+            core.setOutput('tag', highestTag);
+            core.setOutput('major_tag', majorTag);
+            core.setOutput('is_highest', tag === highestTag ? 'true' : 'false');
+      - name: Check out code
+        if: steps.highest.outputs.is_highest == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.highest.outputs.tag }}
+      - name: Update major version tags
+        if: steps.highest.outputs.is_highest == 'true'
+      - uses: haya14busa/action-update-semver@v1
+        with:
+          tag: ${{ steps.highest.outputs.tag }}
+          major_version_tag_only: true
+      - name: Update major release description
+        if: steps.highest.outputs.is_highest == 'true'
+        uses: actions/github-script@v7
+        env:
+          HIGHEST_TAG: ${{ steps.highest.outputs.tag }}
+          MAJOR_TAG: ${{ steps.highest.outputs.major_tag }}
+        with:
+          script: |
+            const tag = process.env.HIGHEST_TAG;
+            const majorTag = process.env.MAJOR_TAG;
             const newBody = `Major ${majorTag}. Keeps updated to the latest version in this major (${tag}).`;
             try {
               const { data: release } = await octokit.rest.repos.getReleaseByTag({

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,0 +1,53 @@
+name: Update major version tag
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-major-tag:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: haya14busa/action-update-semver@v1
+        with:
+          tag: ${{ github.event.release.tag_name }}
+          major_version_tag_only: true
+      - name: Update major release description
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = context.payload.release.tag_name;
+            const majorTag = tag.split('.')[0];
+            const newBody = `Major ${majorTag}. Keeps updated to the latest version in this major (${tag}).`;
+            try {
+              const { data: release } = await octokit.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: majorTag,
+              });
+              await octokit.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: release.id,
+                body: newBody,
+              });
+            } catch (err) {
+              if (err.status === 404) {
+                await octokit.rest.repos.createRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag_name: majorTag,
+                  name: majorTag,
+                  body: newBody,
+                });
+              } else {
+                throw err;
+              }
+            }

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,4 +1,4 @@
-name: Update major version tag
+name: Update major version tag/release
 
 on:
   release:


### PR DESCRIPTION
The added workflow automatically creates or updates tags and releases of major versions when a release is published. It only runs when releases are published as stable (not marked with `prerelease` flag). The workflow steps are:

1. Verify if the major doesn't exist or the published release is the highest in this major (`is_highest`).
2. [`if is_highest == true`] Use [haya14busa/action-update-semver](https://github.com/haya14busa/action-update-semver) to create (if doesn't exist) or update (if exists) the major tag.
3. [`if is_highest == true`] If the major release exists, update the description to reflect the new version. If it doesn't exist, create the release with the description.