### PR TITLE
Update Dockerfile to Python 3.11 + model in categorization script to Gemini 2.5 Flash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
@@ -6,4 +6,4 @@ RUN pip install -r requirements.txt
 COPY . /action
 WORKDIR /action
 
-ENTRYPOINT ["python", "/action/src/main.py"] 
+ENTRYPOINT ["python", "/action/src/main.py"]

--- a/src/categorize_doc.py
+++ b/src/categorize_doc.py
@@ -48,7 +48,7 @@ def categorize_doc(file_path: str, client: genai.Client) -> dict:
     ]
   
     response_text = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=contents,
         config=generate_content_config,
     )


### PR DESCRIPTION
- Update from Python 3.9 to 3.11: Python 3.9 is deprecated and [gives warnings](https://github.com/vtexdocs/dev-portal-content/actions/runs/21694261998/job/62561018497?pr=2462#step:5:7). Update to 3.11 [doesn't show warnings](https://github.com/vtexdocs/action-tester/actions/runs/21727360230/job/62672833303#step:5:7).
- Update model in categorization script from Gemini 2.0 Flash to 2.5 Flash: 2.0 Flash gives [exceeded quota error](https://github.com/vtexdocs/dev-portal-content/actions/runs/21694261998/job/62561018497?pr=2462#step:5:75). Changing to 2.5 Flash [runs as intended](https://github.com/vtexdocs/action-tester/actions/runs/21727360230/job/62672833303#step:5:88).