### PR TITLE
Add gemini-3.5-flash as primary feedback model

### DIFF
--- a/src/categorize_doc.py
+++ b/src/categorize_doc.py
@@ -48,6 +48,7 @@ def categorize_doc(file_path: str, client: genai.Client) -> dict:
     ]
 
     GEMINI_MODELS = (
+        "gemini-3-flash-preview",
         "gemini-2.5-flash",
         "gemini-3.1-flash-lite-preview",
     )

--- a/src/categorize_doc.py
+++ b/src/categorize_doc.py
@@ -48,9 +48,8 @@ def categorize_doc(file_path: str, client: genai.Client) -> dict:
     ]
 
     GEMINI_MODELS = (
-        "gemini-3-flash-preview",
         "gemini-2.5-flash",
-        "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite",
     )
 
     last_error: BaseException | None = None

--- a/src/generate_feedback.py
+++ b/src/generate_feedback.py
@@ -40,6 +40,7 @@ def generate_feedback(file_path, documentation, rules, client):
     ]
 
     GEMINI_MODELS = (
+        "gemini-3.5-flash",
         "gemini-3-flash-preview",
         "gemini-2.5-flash",
         "gemini-3.1-flash-lite-preview",

--- a/src/generate_feedback.py
+++ b/src/generate_feedback.py
@@ -43,7 +43,7 @@ def generate_feedback(file_path, documentation, rules, client):
         "gemini-3.5-flash",
         "gemini-3-flash-preview",
         "gemini-2.5-flash",
-        "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite",
     )
 
     last_error: BaseException | None = None


### PR DESCRIPTION
## Summary
- Adds `gemini-3.5-flash` as the first model in `GEMINI_MODELS` for feedback generation.
- Update Gemini 3.1 Flash Lite from preview to stable as fallback model.

Made with [Cursor](https://cursor.com)